### PR TITLE
feat(config): add Forgejo v13 settings and bump to 13.0.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ devbox run -- ansible-lint .
   4. Verifies installation
 
 ### Key Variables (defaults/main.yml)
-- `forgejo_target_version`: Version to install (default: "12.0.3")
+- `forgejo_target_version`: Version to install (default: "13.0.5")
 - `forgejo_install_path`: Installation directory (default: "/usr/local/bin")
 - `forgejo_os`: OS for binary (default: "linux" - only Linux binaries available currently)
 - `forgejo_arch`: Architecture (default: "amd64", options: "amd64", "arm64")
@@ -57,7 +57,7 @@ devbox run -- ansible-lint .
 
 1. **Path Issues**: Always use full paths (`{{ forgejo_install_path }}/forgejo`) in commands since PATH may not be set correctly during Ansible execution
 
-2. **Version Comparison**: The role compares exact version strings. The downloaded version has "v" prefix (e.g., "v12.0.3") which is stripped for comparison
+2. **Version Comparison**: The role compares exact version strings. The downloaded version has "v" prefix (e.g., "v13.0.5") which is stripped for comparison
 
 3. **Conditional Logic**: Uses `("v" + forgejo_target_version)` syntax to avoid Jinja2 templating warnings in conditionals
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This role implements the [binary installation method](https://forgejo.org/docs/l
 - Ansible >= 2.15
 - Linux system (required - Forgejo only provides Linux binaries)
 - Internet connectivity to download Forgejo releases from Codeberg
+- Git >= 2.34.1 on the target host (required by Forgejo >= 13.0)
 
 ## Role Variables
 
@@ -34,7 +35,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
 ```yaml
 # Target version of Forgejo to install
-forgejo_target_version: "12.0.3"
+forgejo_target_version: "13.0.5"
 
 # Installation directory for the forgejo binary
 forgejo_install_path: "/usr/local/bin"
@@ -107,6 +108,9 @@ forgejo_server_ssh_listen_port: 2222            # Internal SSH listen port
 forgejo_security_secret_key: ""                 # Secret key for encryption
 forgejo_security_internal_token: ""             # Internal API token
 
+# v13+: enforce two-factor authentication instance-wide (none, all, admin)
+forgejo_security_global_two_factor_requirement: "none"
+
 # Service settings
 forgejo_service_disable_registration: false      # Allow new user registration
 forgejo_service_require_signin_view: false      # Require login to view content
@@ -121,6 +125,18 @@ forgejo_mailer_protocol: "sendmail"             # Protocol: sendmail or smtp
 forgejo_mailer_smtp_addr: ""                    # SMTP server address
 forgejo_mailer_smtp_port: 587                   # SMTP server port
 forgejo_mailer_from: "Forgejo <noreply@localhost>" # From address
+# v13+: read the SMTP password from a file instead of forgejo_mailer_passwd.
+# When set, it takes precedence over forgejo_mailer_passwd.
+forgejo_mailer_passwd_uri: ""                   # e.g. "file:/etc/forgejo/mailer_passwd"
+```
+
+#### Moderation Configuration (v13+)
+
+Forgejo 13 added a content reporting / abuse-report system. You can enable a cron task that periodically removes reports already resolved by administrators:
+
+```yaml
+forgejo_cron_remove_resolved_reports_enabled: false      # Enable the cleanup cron task
+forgejo_cron_remove_resolved_reports_schedule: "@every 24h"  # Cron schedule for the cleanup
 ```
 
 ### Advanced Configuration
@@ -159,7 +175,7 @@ None.
 - hosts: servers
   become: yes
   vars:
-    forgejo_target_version: "12.0.3"
+    forgejo_target_version: "13.0.5"
   roles:
     - sgaunet.forgejo
 ```
@@ -183,14 +199,14 @@ None.
 - hosts: production
   become: yes
   vars:
-    forgejo_target_version: "12.0.3"
+    forgejo_target_version: "13.0.5"
   roles:
     - sgaunet.forgejo
 
 - hosts: staging
   become: yes
   vars:
-    forgejo_target_version: "12.0.2"
+    forgejo_target_version: "13.0.4"
   roles:
     - sgaunet.forgejo
 ```
@@ -317,6 +333,8 @@ ansible-role-forgejo/
 - **Debian**: 11 (Bullseye), 12 (Bookworm)
 - **Fedora**: 38, 39, 40
 
+**Note**: Forgejo >= 13.0 requires Git >= 2.34.1 on the target host. The default Git packages on **Ubuntu 20.04 (Focal, git 2.25)** and **Debian 11 (Bullseye, git 2.30)** are older than this; on those distros a newer Git (e.g. from a backport/PPA) must be installed for Forgejo 13 to run. EL 8/9, Ubuntu 22.04+ , Debian 12, and Fedora 38-40 ship a recent enough Git.
+
 **Note**: Forgejo currently only provides Linux binaries. The `forgejo_os` variable is available for future compatibility when other operating systems are supported.
 
 ## Contributing
@@ -345,7 +363,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 2. **Download Failures**: Check your internet connectivity and firewall rules for accessing Codeberg
 
-3. **Version Not Changing**: The role compares exact version strings. Ensure `forgejo_target_version` matches the release version format (e.g., "12.0.3" not "v12.0.3")
+3. **Version Not Changing**: The role compares exact version strings. Ensure `forgejo_target_version` matches the release version format (e.g., "13.0.5" not "v13.0.5")
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for ansible-role-forgejo
 
 # Forgejo version and installation settings
-forgejo_target_version: "12.0.3"
+forgejo_target_version: "13.0.5"
 forgejo_install_path: "/usr/local/bin"  # Installation directory for the forgejo binary
 forgejo_os: "linux"  # Currently only linux binaries are available
 forgejo_arch: "amd64"  # Options: amd64, arm64
@@ -59,9 +59,16 @@ forgejo_security_secret_key: ""  # Auto-generated if empty (used for encryption 
 forgejo_security_internal_token: ""  # Auto-generated if empty (used for internal API calls)
 forgejo_security_min_password_length: 6  # Minimum password length
 forgejo_security_disable_git_hooks: true  # Prevent custom Git hooks for security
+# v13+: enforce two-factor authentication instance-wide. Options: none, all, admin
+forgejo_security_global_two_factor_requirement: "none"
 
 # OAuth2 configuration
 forgejo_oauth2_jwt_secret: ""  # Auto-generated if empty (used for OAuth2 JWT authentication)
+
+# Moderation configuration (v13+: content reporting / abuse reports)
+# Periodically remove abuse reports that have already been resolved by administrators
+forgejo_cron_remove_resolved_reports_enabled: false  # Enable the cleanup cron task
+forgejo_cron_remove_resolved_reports_schedule: "@every 24h"  # Cron schedule for the cleanup
 
 # Service configuration
 forgejo_service_disable_registration: false
@@ -82,6 +89,9 @@ forgejo_mailer_smtp_addr: ""
 forgejo_mailer_smtp_port: 587
 forgejo_mailer_user: ""
 forgejo_mailer_passwd: ""
+# v13+: read the SMTP password from a file instead of forgejo_mailer_passwd.
+# When set (e.g. "file:/etc/forgejo/mailer_passwd") it takes precedence over forgejo_mailer_passwd.
+forgejo_mailer_passwd_uri: ""
 forgejo_mailer_from: "Forgejo <noreply@{{ forgejo_server_domain }}>"
 
 # Cache configuration

--- a/templates/app.ini.j2
+++ b/templates/app.ini.j2
@@ -56,6 +56,7 @@ SECRET_KEY = {{ forgejo_security_secret_key }}
 INTERNAL_TOKEN = {{ forgejo_security_internal_token }}
 MIN_PASSWORD_LENGTH = {{ forgejo_security_min_password_length }}
 DISABLE_GIT_HOOKS = {{ forgejo_security_disable_git_hooks | lower }}
+GLOBAL_TWO_FACTOR_REQUIREMENT = {{ forgejo_security_global_two_factor_requirement }}
 
 [service]
 DISABLE_REGISTRATION = {{ forgejo_service_disable_registration | lower }}
@@ -78,7 +79,11 @@ PROTOCOL = {{ forgejo_mailer_protocol }}
 SMTP_ADDR = {{ forgejo_mailer_smtp_addr }}
 SMTP_PORT = {{ forgejo_mailer_smtp_port }}
 USER = {{ forgejo_mailer_user }}
+{% if forgejo_mailer_passwd_uri %}
+PASSWD_URI = {{ forgejo_mailer_passwd_uri }}
+{% else %}
 PASSWD = {{ forgejo_mailer_passwd }}
+{% endif %}
 {% endif %}
 FROM = {{ forgejo_mailer_from }}
 {% endif %}
@@ -120,7 +125,7 @@ MAX_FILES = {{ forgejo_attachment_max_files }}
 MODE = {{ forgejo_log_mode }}
 ROOT_PATH = {{ forgejo_data_path }}/log
 LEVEL = {{ forgejo_log_level }}
-logger.router.MODE = {{ forgejo_log_router }}
+LOGGER_ROUTER_MODE = {{ forgejo_log_router }}
 
 {% if forgejo_log_enable_access_log %}
 [log.logger.access]
@@ -139,4 +144,8 @@ PULL = {{ forgejo_git_timeout_pull }}
 GC = {{ forgejo_git_timeout_gc }}
 
 [oauth2]
-JWT_SECRET = {{ forgejo_oauth2_jwt_secret }} 
+JWT_SECRET = {{ forgejo_oauth2_jwt_secret }}
+
+[cron.remove_resolved_reports]
+ENABLED = {{ forgejo_cron_remove_resolved_reports_enabled | lower }}
+SCHEDULE = {{ forgejo_cron_remove_resolved_reports_schedule }}


### PR DESCRIPTION
- bump forgejo_target_version to 13.0.5 (latest 13.x patch)
- add GLOBAL_TWO_FACTOR_REQUIREMENT ([security], v13 2FA enforcement)
- add cron.remove_resolved_reports moderation report cleanup
- add mailer PASSWD_URI to read the SMTP password from a file
- migrate logger.router.MODE to v13 syntax LOGGER_ROUTER_MODE
- document new variables and the Git >= 2.34.1 runtime requirement

Closes #14