### PR TITLE
feat(config): add Forgejo v14 support and bump to 14.0.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ devbox run -- ansible-lint .
   4. Verifies installation
 
 ### Key Variables (defaults/main.yml)
-- `forgejo_target_version`: Version to install (default: "13.0.5")
+- `forgejo_target_version`: Version to install (default: "14.0.5")
 - `forgejo_install_path`: Installation directory (default: "/usr/local/bin")
 - `forgejo_os`: OS for binary (default: "linux" - only Linux binaries available currently)
 - `forgejo_arch`: Architecture (default: "amd64", options: "amd64", "arm64")
@@ -57,7 +57,7 @@ devbox run -- ansible-lint .
 
 1. **Path Issues**: Always use full paths (`{{ forgejo_install_path }}/forgejo`) in commands since PATH may not be set correctly during Ansible execution
 
-2. **Version Comparison**: The role compares exact version strings. The downloaded version has "v" prefix (e.g., "v13.0.5") which is stripped for comparison
+2. **Version Comparison**: The role compares exact version strings. The downloaded version has "v" prefix (e.g., "v14.0.5") which is stripped for comparison
 
 3. **Conditional Logic**: Uses `("v" + forgejo_target_version)` syntax to avoid Jinja2 templating warnings in conditionals
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
 ```yaml
 # Target version of Forgejo to install
-forgejo_target_version: "13.0.5"
+forgejo_target_version: "14.0.5"
 
 # Installation directory for the forgejo binary
 forgejo_install_path: "/usr/local/bin"
@@ -100,6 +100,9 @@ forgejo_server_root_url: "http://localhost:3000/" # Full URL to Forgejo
 forgejo_server_disable_ssh: false               # Disable SSH access
 forgejo_server_ssh_port: 22                     # SSH port for Git operations
 forgejo_server_ssh_listen_port: 2222            # Internal SSH listen port
+# v14+: allow unexpected keys in the managed authorized_keys file instead of
+# aborting startup (set true only when migrating an instance with hand-added keys)
+forgejo_server_ssh_allow_unexpected_authorized_keys: false
 ```
 
 #### Security & Service Configuration
@@ -175,7 +178,7 @@ None.
 - hosts: servers
   become: yes
   vars:
-    forgejo_target_version: "13.0.5"
+    forgejo_target_version: "14.0.5"
   roles:
     - sgaunet.forgejo
 ```
@@ -199,14 +202,14 @@ None.
 - hosts: production
   become: yes
   vars:
-    forgejo_target_version: "13.0.5"
+    forgejo_target_version: "14.0.5"
   roles:
     - sgaunet.forgejo
 
 - hosts: staging
   become: yes
   vars:
-    forgejo_target_version: "13.0.4"
+    forgejo_target_version: "14.0.4"
   roles:
     - sgaunet.forgejo
 ```
@@ -337,6 +340,13 @@ ansible-role-forgejo/
 
 **Note**: Forgejo currently only provides Linux binaries. The `forgejo_os` variable is available for future compatibility when other operating systems are supported.
 
+## Upgrade Notes
+
+When upgrading an **existing** Forgejo instance (not a fresh install), always back up first, as recommended in the [official upgrade guide](https://forgejo.org/docs/latest/admin/upgrade/). Two v14-specific points:
+
+- **SSH `authorized_keys` validation**: on startup Forgejo validates the managed `authorized_keys` file and aborts if it contains unexpected keys. If you manually added keys, either let Forgejo regenerate the file or set `forgejo_server_ssh_allow_unexpected_authorized_keys: true`.
+- **Database foreign keys**: the v14 (v41 schema) migration adds foreign keys and may surface pre-existing data inconsistencies. If the migration errors, run `forgejo doctor check --all` to identify the affected records.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
@@ -363,7 +373,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 2. **Download Failures**: Check your internet connectivity and firewall rules for accessing Codeberg
 
-3. **Version Not Changing**: The role compares exact version strings. Ensure `forgejo_target_version` matches the release version format (e.g., "13.0.5" not "v13.0.5")
+3. **Version Not Changing**: The role compares exact version strings. Ensure `forgejo_target_version` matches the release version format (e.g., "14.0.5" not "v14.0.5")
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for ansible-role-forgejo
 
 # Forgejo version and installation settings
-forgejo_target_version: "13.0.5"
+forgejo_target_version: "14.0.5"
 forgejo_install_path: "/usr/local/bin"  # Installation directory for the forgejo binary
 forgejo_os: "linux"  # Currently only linux binaries are available
 forgejo_arch: "amd64"  # Options: amd64, arm64
@@ -37,6 +37,9 @@ forgejo_server_disable_ssh: false
 forgejo_server_ssh_domain: "{{ forgejo_server_domain }}"
 forgejo_server_ssh_port: 22
 forgejo_server_ssh_listen_port: 2222
+# v14+: allow unexpected keys in the managed SSH authorized_keys file instead of
+# aborting startup. Leave false unless migrating an instance with hand-added keys.
+forgejo_server_ssh_allow_unexpected_authorized_keys: false
 forgejo_server_lfs_start_server: true
 forgejo_server_lfs_jwt_secret: ""  # Auto-generated if empty (used for LFS JWT authentication)
 forgejo_server_enable_gzip: false

--- a/templates/app.ini.j2
+++ b/templates/app.ini.j2
@@ -30,6 +30,7 @@ START_SSH_SERVER = {{ (not forgejo_server_disable_ssh) | lower }}
 SSH_DOMAIN = {{ forgejo_server_ssh_domain }}
 SSH_PORT = {{ forgejo_server_ssh_port }}
 SSH_LISTEN_PORT = {{ forgejo_server_ssh_listen_port }}
+SSH_ALLOW_UNEXPECTED_AUTHORIZED_KEYS = {{ forgejo_server_ssh_allow_unexpected_authorized_keys | lower }}
 OFFLINE_MODE = false
 {% endif %}
 LFS_START_SERVER = {{ forgejo_server_lfs_start_server | lower }}


### PR DESCRIPTION
- bump forgejo_target_version to 14.0.5 (latest 14.x patch)
- add SSH_ALLOW_UNEXPECTED_AUTHORIZED_KEYS ([server], v14 authorized_keys bypass)
- document the new variable and v14 upgrade caveats (SSH key validation, forgejo doctor)

Closes #16