### PR TITLE
fix(service): restart service after binary upgrade

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,6 +81,8 @@
         group: "{{ forgejo_group }}"
         mode: "0755"
         remote_src: true
+      notify:
+        - Restart forgejo service
 
     - name: Remove temporary download directory
       ansible.builtin.file:


### PR DESCRIPTION
Add a notify to the binary install task so a changed Forgejo binary triggers the existing "Restart forgejo service" handler. Without it the running systemd process kept executing the old in-memory binary after an upgrade, so the service reported the old version despite the new binary on disk.

Closes #18