### PR TITLE
feat(runner): support Forgejo Runner v12

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,13 @@ devbox run -- ansible-lint .
 - `forgejo_install_path`: Installation directory (default: "/usr/local/bin")
 - `forgejo_os`: OS for binary (default: "linux" - only Linux binaries available currently)
 - `forgejo_arch`: Architecture (default: "amd64", options: "amd64", "arm64")
+- `forgejo_runner_version`: Optional CI/CD runner version (default: "12.10.2")
+
+### Forgejo Runner (tasks/runner.yml, optional via `forgejo_runner_enabled`)
+- Runner **v12+ requires git on the host**; the role installs it when `forgejo_runner_install_git` is true.
+- v12 deprecated the `register` command: the connection is declared in a managed `config.yml` (templates/config.yml.j2) under `server.connections`, rendered only when `forgejo_runner_instance_url` and `forgejo_runner_registration_token` are both set.
+- Runner binary download URL uses `code.forgejo.org` (not `codeberg.org`):
+  `https://code.forgejo.org/forgejo/runner/releases/download/v{{ forgejo_runner_version }}/forgejo-runner-{{ forgejo_runner_version }}-{{ forgejo_runner_os }}-{{ forgejo_runner_arch }}`
 
 ### Testing Strategy
 - Uses Molecule with Docker driver

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This role implements the [binary installation method](https://forgejo.org/docs/l
 - Sets up systemd service with proper configuration and dependencies
 - Version management with automatic upgrades/downgrades
 - Idempotent installation (only downloads when version differs)
+- Optional Forgejo Runner (CI/CD) install with config-based registration (v12 model)
 - Support for multiple Linux distributions
 - Comprehensive molecule tests
 
@@ -157,6 +158,51 @@ forgejo_os: "linux"
 
 # Architecture (default: amd64, options: amd64, arm64)
 forgejo_arch: "amd64"
+```
+
+### Forgejo Runner (CI/CD)
+
+The role can optionally install and configure the [Forgejo Runner](https://forgejo.org/docs/latest/admin/actions/) (Forgejo Actions). It is disabled by default. When enabled, the role installs the runner binary, creates a dedicated `runner` user, deploys a managed `config.yml`, and sets up a hardened systemd service.
+
+> **Runner v12+ requires `git` on the host** (used by `checkout` and remote actions via git worktrees). The role installs git automatically when the runner is enabled (`forgejo_runner_install_git: true`).
+
+Forgejo Runner v12 also replaces the deprecated `register` command: the connection to a Forgejo instance is declared directly in `config.yml` under `server.connections`. Obtain a registration token (and UUID) from the Forgejo UI (admin: `/admin/actions/runners`, or an org/user/repo's *Settings → Actions → Runners*) and pass it to the role. The connection block is only written when both URL and token are provided.
+
+```yaml
+# Forgejo Runner configuration (optional CI/CD runner)
+forgejo_runner_enabled: false           # Enable runner installation and service
+forgejo_runner_version: "12.10.2"       # Runner version to install
+forgejo_runner_install_git: true        # Install git (required by runner v12+)
+
+# Connection / registration (v12 model — declared in config.yml, no `register` command)
+forgejo_runner_instance_url: ""         # e.g. "https://forge.example.com/"
+forgejo_runner_registration_token: ""   # Token from the Forgejo UI (store via Ansible Vault)
+forgejo_runner_uuid: ""                 # Optional runner UUID shown alongside the token
+forgejo_runner_connection_name: "forgejo"  # Key used under server.connections
+
+# Runner behaviour
+forgejo_runner_log_level: "info"        # trace, debug, info, warn, error
+forgejo_runner_capacity: 1              # Concurrent jobs
+forgejo_runner_timeout: 3600           # Job timeout in seconds
+forgejo_runner_insecure: false          # Skip TLS verification (not recommended)
+forgejo_runner_labels: []               # e.g. ["docker:docker://node:20-bookworm"]
+forgejo_runner_enable_docker: false     # Add runner user to the docker group
+```
+
+Example enabling a registered runner:
+
+```yaml
+---
+- hosts: ci
+  become: true
+  vars:
+    forgejo_runner_enabled: true
+    forgejo_runner_instance_url: "https://forge.example.com/"
+    forgejo_runner_registration_token: "{{ vault_forgejo_runner_token }}"
+    forgejo_runner_labels:
+      - "docker:docker://node:20-bookworm"
+  roles:
+    - sgaunet.forgejo
 ```
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,10 +152,13 @@ forgejo_service_enable_capabilities: false  # Enable CAP_NET_BIND_SERVICE for lo
 
 # Forgejo Runner configuration (optional CI/CD runner)
 forgejo_runner_enabled: false  # Enable Forgejo Runner installation and service
-forgejo_runner_version: "11.0.0"  # Runner version to install
+forgejo_runner_version: "12.10.2"  # Runner version to install
 forgejo_runner_install_path: "/usr/local/bin"  # Installation directory for runner binary
 forgejo_runner_os: "linux"  # Operating system for runner binary
 forgejo_runner_arch: "{{ forgejo_arch }}"  # Architecture (matches Forgejo arch by default)
+# Runner v12+ requires a git binary on the host (used for checkout / remote actions via git
+# worktrees). The role installs git when the runner is enabled; set to false to manage it yourself.
+forgejo_runner_install_git: true
 
 # Runner user configuration
 forgejo_runner_user: "runner"  # Username for runner service
@@ -177,6 +180,17 @@ forgejo_runner_capacity: 1  # Number of concurrent jobs the runner can handle
 forgejo_runner_timeout: 3600  # Job timeout in seconds (1 hour default)
 forgejo_runner_insecure: false  # Skip TLS certificate verification (not recommended for production)
 forgejo_runner_labels: []  # Labels for the runner (e.g., ["docker:docker://node:20-bookworm"])
+forgejo_runner_runner_file: "{{ forgejo_runner_data_path }}/.runner"  # Registration state file
+
+# Runner connection / registration (Forgejo Runner v12 model)
+# The deprecated `register` command is no longer used; the connection to a Forgejo instance is
+# declared directly in config.yml under server.connections. Obtain the token (and uuid) from the
+# Forgejo UI runners page (admin: /admin/actions/runners, org/user/repo settings -> Actions ->
+# Runners). The server.connections block is only rendered when both URL and token are provided.
+forgejo_runner_instance_url: ""  # e.g. "https://forge.example.com/"
+forgejo_runner_registration_token: ""  # Registration token (store via Ansible Vault)
+forgejo_runner_uuid: ""  # Optional runner UUID shown alongside the token in the UI
+forgejo_runner_connection_name: "forgejo"  # Key used under server.connections
 
 # Docker/Podman support for runner (optional)
 forgejo_runner_enable_docker: false  # Add runner user to docker group (requires Docker installed)

--- a/molecule/default/converge-runner.yml
+++ b/molecule/default/converge-runner.yml
@@ -6,6 +6,13 @@
     forgejo_security_secret_key: "VerySecureSecretKeyForTestingOnly1234567890"
     forgejo_security_internal_token: "VerySecureInternalTokenForTestingOnly1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyz"
     forgejo_runner_enabled: true
+    # Exercise the server.connections template branch (config render only; the runner cannot
+    # actually connect to a Forgejo instance in this isolated test).
+    forgejo_runner_instance_url: "http://localhost:3000/"
+    forgejo_runner_registration_token: "TestRegistrationTokenForMoleculeOnly1234"
+    forgejo_runner_uuid: "00000000-0000-0000-0000-000000000000"
+    forgejo_runner_labels:
+      - "docker:docker://node:20-bookworm"
   tasks:
     - name: "Include sgaunet.forgejo role with runner"
       ansible.builtin.include_role:

--- a/molecule/default/verify-runner.yml
+++ b/molecule/default/verify-runner.yml
@@ -35,6 +35,25 @@
       changed_when: false
       failed_when: runner_user_check.rc != 0
 
+    - name: Check git is installed (required by runner v12+)
+      ansible.builtin.command: git --version
+      register: git_check
+      changed_when: false
+      failed_when: git_check.rc != 0
+
+    - name: Get installed forgejo-runner version
+      ansible.builtin.command: >-
+        {{ forgejo_runner_install_path | default('/usr/local/bin') }}/forgejo-runner --version
+      register: runner_version_check
+      changed_when: false
+
+    - name: Verify forgejo-runner is the expected major version (v12)
+      ansible.builtin.assert:
+        that:
+          - "'v12.' in runner_version_check.stdout"
+        fail_msg: "forgejo-runner is not a v12 release: {{ runner_version_check.stdout }}"
+        success_msg: "forgejo-runner v12 is installed"
+
     - name: Stat runner configuration directory
       ansible.builtin.stat:
         path: "{{ forgejo_runner_config_path | default('/etc/forgejo-runner') }}"
@@ -59,6 +78,19 @@
           - runner_config_file.stat.exists
         fail_msg: "Runner configuration file not created"
         success_msg: "Runner configuration file exists"
+
+    - name: Read runner configuration file
+      ansible.builtin.slurp:
+        src: "{{ forgejo_runner_config_path | default('/etc/forgejo-runner') }}/config.yml"
+      register: runner_config_content
+
+    - name: Verify runner configuration is role-managed and contains the connection
+      ansible.builtin.assert:
+        that:
+          - "'managed by the sgaunet.forgejo Ansible role' in (runner_config_content.content | b64decode)"
+          - "'connections:' in (runner_config_content.content | b64decode)"
+        fail_msg: "Runner config.yml is not the expected managed template"
+        success_msg: "Runner config.yml is managed and declares a server connection"
 
     - name: Check forgejo-runner service file exists
       ansible.builtin.stat:

--- a/tasks/runner.yml
+++ b/tasks/runner.yml
@@ -27,6 +27,14 @@
     - forgejo_runner_enable_docker | bool
     - ansible_facts.getent_group.docker is defined
 
+# Forgejo Runner v12+ requires a git binary on the host (checkout / remote actions use git
+# worktrees). The role does not otherwise install git, so install it here when enabled.
+- name: Install git for Forgejo Runner (required by runner v12+)
+  ansible.builtin.package:
+    name: git
+    state: present
+  when: forgejo_runner_install_git | bool
+
 - name: Create runner configuration directory
   ansible.builtin.file:
     path: "{{ forgejo_runner_config_path }}"
@@ -102,79 +110,16 @@
       ansible.builtin.debug:
         msg: "Forgejo Runner installed: {{ forgejo_runner_verify.stdout }}"
 
-- name: Check if runner config exists
-  ansible.builtin.stat:
-    path: "{{ forgejo_runner_config_path }}/config.yml"
-  register: runner_config_stat
-
-- name: Create runner home .ansible/tmp directory
-  ansible.builtin.file:
-    path: "{{ forgejo_runner_home }}/.ansible/tmp"
-    state: directory
-    owner: "{{ forgejo_runner_user }}"
-    group: "{{ forgejo_runner_group }}"
-    mode: '0700'
-  when: not runner_config_stat.stat.exists
-
-- name: Generate default runner configuration
-  ansible.builtin.shell: |
-    {{ forgejo_runner_install_path }}/forgejo-runner generate-config > {{ forgejo_runner_config_path }}/config.yml
-  args:
-    creates: "{{ forgejo_runner_config_path }}/config.yml"
-  become: true
-  become_user: "{{ forgejo_runner_user }}"
-  when: not runner_config_stat.stat.exists
-
-- name: Check if runner config exists after generation
-  ansible.builtin.stat:
-    path: "{{ forgejo_runner_config_path }}/config.yml"
-  register: runner_config_final_stat
-
-- name: Set runner configuration file permissions
-  ansible.builtin.file:
-    path: "{{ forgejo_runner_config_path }}/config.yml"
+# config.yml is fully managed by the role via a template (idempotent and able to express the
+# nested server.connections block introduced in runner v12). This replaces the older
+# `generate-config` + lineinfile approach.
+- name: Deploy Forgejo Runner configuration
+  ansible.builtin.template:
+    src: config.yml.j2
+    dest: "{{ forgejo_runner_config_path }}/config.yml"
     owner: "{{ forgejo_runner_user }}"
     group: "{{ forgejo_runner_group }}"
     mode: '0640'
-  when: runner_config_final_stat.stat.exists
-
-- name: Update runner log level in configuration
-  ansible.builtin.lineinfile:
-    path: "{{ forgejo_runner_config_path }}/config.yml"
-    regexp: '^(\s*)level:'
-    line: '  level: {{ forgejo_runner_log_level }}'
-    backup: true
-  when: runner_config_final_stat.stat.exists
-  notify:
-    - Restart forgejo-runner service
-
-- name: Update runner capacity in configuration
-  ansible.builtin.lineinfile:
-    path: "{{ forgejo_runner_config_path }}/config.yml"
-    regexp: '^(\s*)capacity:'
-    line: '  capacity: {{ forgejo_runner_capacity }}'
-    backup: true
-  when: runner_config_final_stat.stat.exists
-  notify:
-    - Restart forgejo-runner service
-
-- name: Update runner timeout in configuration
-  ansible.builtin.lineinfile:
-    path: "{{ forgejo_runner_config_path }}/config.yml"
-    regexp: '^(\s*)timeout:'
-    line: '  timeout: {{ forgejo_runner_timeout }}s'
-    backup: true
-  when: runner_config_final_stat.stat.exists
-  notify:
-    - Restart forgejo-runner service
-
-- name: Update runner insecure setting in configuration
-  ansible.builtin.lineinfile:
-    path: "{{ forgejo_runner_config_path }}/config.yml"
-    regexp: '^(\s*)insecure:'
-    line: '  insecure: {{ forgejo_runner_insecure | lower }}'
-    backup: true
-  when: runner_config_final_stat.stat.exists
   notify:
     - Restart forgejo-runner service
 

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -1,0 +1,27 @@
+# {{ ansible_managed }}
+# Forgejo Runner configuration managed by the sgaunet.forgejo Ansible role.
+# Only the keys managed by the role are listed here; any option left out falls back to the
+# runner's built-in default. See the upstream config.example.yaml for the full reference:
+# https://code.forgejo.org/forgejo/runner/src/branch/main/internal/pkg/config/config.example.yaml
+---
+log:
+  level: {{ forgejo_runner_log_level }}
+
+runner:
+  file: {{ forgejo_runner_runner_file }}
+  capacity: {{ forgejo_runner_capacity }}
+  timeout: {{ forgejo_runner_timeout }}s
+  insecure: {{ forgejo_runner_insecure | lower }}
+  labels: {{ forgejo_runner_labels | to_json }}
+{% if forgejo_runner_instance_url and forgejo_runner_registration_token %}
+
+# Connection to the Forgejo instance (v12 replaces the deprecated `register` command).
+server:
+  connections:
+    {{ forgejo_runner_connection_name }}:
+      url: {{ forgejo_runner_instance_url }}
+{% if forgejo_runner_uuid %}
+      uuid: {{ forgejo_runner_uuid }}
+{% endif %}
+      token: {{ forgejo_runner_registration_token }}
+{% endif %}


### PR DESCRIPTION
- bump forgejo_runner_version to 12.10.2
- install git when runner enabled (required by runner v12+)
- declare instance connection in managed config.yml (server.connections), replacing the deprecated register command
- add forgejo_runner_install_git and connection variables
- replace generate-config + lineinfile with templates/config.yml.j2
- update molecule runner tests and docs (README, CLAUDE.md)

Closes #22