### PR TITLE
feat(runner): support all config keys via role variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,8 @@ devbox run -- ansible-lint .
 
 ### Forgejo Runner (tasks/runner.yml, optional via `forgejo_runner_enabled`)
 - Runner **v12+ requires git on the host**; the role installs it when `forgejo_runner_install_git` is true.
-- v12 deprecated the `register` command: the connection is declared in a managed `config.yml` (templates/config.yml.j2) under `server.connections`, rendered only when `forgejo_runner_instance_url` and `forgejo_runner_registration_token` are both set.
+- v12 deprecated the `register` command: the connection is declared in a managed `config.yml` (templates/config.yml.j2) under `server.connections`, rendered only when `forgejo_runner_instance_url` plus a token (`forgejo_runner_registration_token` or `forgejo_runner_token_url`) are set.
+- `config.yml.j2` exposes **every** runner config key (log/runner/cache/container/host/server) via per-key `forgejo_runner_*` vars, plus a deep-merged `forgejo_runner_extra_config` escape hatch. The template builds a dict and renders it with `to_nice_yaml`; keys whose variable is empty (`""`/`[]`/`{}`) are omitted so the runner uses its own default (empty string is the "unset" sentinel, giving booleans a tri-state).
 - Runner binary download URL uses `code.forgejo.org` (not `codeberg.org`):
   `https://code.forgejo.org/forgejo/runner/releases/download/v{{ forgejo_runner_version }}/forgejo-runner-{{ forgejo_runner_version }}-{{ forgejo_runner_os }}-{{ forgejo_runner_arch }}`
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ The role can optionally install and configure the [Forgejo Runner](https://forge
 
 > **Runner v12+ requires `git` on the host** (used by `checkout` and remote actions via git worktrees). The role installs git automatically when the runner is enabled (`forgejo_runner_install_git: true`).
 
-Forgejo Runner v12 also replaces the deprecated `register` command: the connection to a Forgejo instance is declared directly in `config.yml` under `server.connections`. Obtain a registration token (and UUID) from the Forgejo UI (admin: `/admin/actions/runners`, or an org/user/repo's *Settings → Actions → Runners*) and pass it to the role. The connection block is only written when both URL and token are provided.
+Forgejo Runner v12 also replaces the deprecated `register` command: the connection to a Forgejo instance is declared directly in `config.yml` under `server.connections`. Obtain a registration token (and UUID) from the Forgejo UI (admin: `/admin/actions/runners`, or an org/user/repo's *Settings → Actions → Runners*) and pass it to the role. The connection block is only written when the URL plus a token (or `token_url`) are provided.
+
+The role can set **every** key the runner supports. Each option below has a `forgejo_runner_*` variable; any variable left empty (`""`, `[]`, `{}`) is **omitted** from `config.yml`, so the runner falls back to its own built-in default. For options not modelled by a dedicated variable — including future upstream keys — use the free-form `forgejo_runner_extra_config` dict, which is deep-merged on top.
 
 ```yaml
 # Forgejo Runner configuration (optional CI/CD runner)
@@ -177,15 +179,60 @@ forgejo_runner_install_git: true        # Install git (required by runner v12+)
 # Connection / registration (v12 model — declared in config.yml, no `register` command)
 forgejo_runner_instance_url: ""         # e.g. "https://forge.example.com/"
 forgejo_runner_registration_token: ""   # Token from the Forgejo UI (store via Ansible Vault)
+forgejo_runner_token_url: ""            # Alternative: file URL for the token, e.g. "file:$CREDENTIALS_DIRECTORY/token.txt"
 forgejo_runner_uuid: ""                 # Optional runner UUID shown alongside the token
 forgejo_runner_connection_name: "forgejo"  # Key used under server.connections
+forgejo_runner_connection_labels: []    # Connection-specific labels (overrides runner.labels)
+forgejo_runner_connection_fetch_interval: ""  # Per-connection job fetch interval, e.g. "5s"
 
-# Runner behaviour
-forgejo_runner_log_level: "info"        # trace, debug, info, warn, error
+# log
+forgejo_runner_log_level: "info"        # Process log level: trace, debug, info, warn, error, fatal
+forgejo_runner_log_job_level: ""        # Log level for logs sent to Forgejo (default: log level)
+
+# runner
 forgejo_runner_capacity: 1              # Concurrent jobs
-forgejo_runner_timeout: 3600           # Job timeout in seconds
+forgejo_runner_timeout: 3600            # Job timeout in seconds (role appends the "s" unit)
 forgejo_runner_insecure: false          # Skip TLS verification (not recommended)
 forgejo_runner_labels: []               # e.g. ["docker:docker://node:20-bookworm"]
+forgejo_runner_envs: {}                 # Extra job env vars, e.g. {KEY: value}
+forgejo_runner_env_file: ""             # Path to a job env file (ignored if missing)
+forgejo_runner_shutdown_timeout: ""     # Grace period for jobs on shutdown, e.g. "3h"
+forgejo_runner_fetch_timeout: ""        # Job fetch timeout, e.g. "5s"
+forgejo_runner_fetch_interval: ""       # Job fetch interval, e.g. "2s"
+forgejo_runner_report_interval: ""      # Status/log report interval, e.g. "1s"
+forgejo_runner_report_retry_max_retries: ""    # Max retries when reporting logs (int)
+forgejo_runner_report_retry_initial_delay: ""  # Initial retry delay, e.g. "100ms"
+forgejo_runner_report_retry_max_delay: ""      # Max retry delay, e.g. "5s"
+
+# cache (internal actions/cache server; upstream default for enabled is true)
+forgejo_runner_cache_enabled: ""        # true/false (empty = runner default, true)
+forgejo_runner_cache_dir: ""            # Cache data dir (empty = $HOME/.cache/actcache)
+forgejo_runner_cache_host: ""           # Host advertised to job containers (empty = auto)
+forgejo_runner_cache_port: ""           # Cache server port (int; 0 = random)
+forgejo_runner_cache_proxy_port: ""     # Cache proxy port (int; 0 = random)
+forgejo_runner_cache_external_server: ""  # External cache server URL (disables internal server)
+forgejo_runner_cache_actions_cache_url_override: ""  # Manual ACTIONS_CACHE_URL for containers
+forgejo_runner_cache_secret: ""         # Cache proxy auth secret (store via Ansible Vault)
+forgejo_runner_cache_secret_url: ""     # File URL for the cache secret (mutually exclusive)
+
+# container (Docker/Podman execution)
+forgejo_runner_container_network: ""    # host, bridge, custom name, or "" to auto-create
+forgejo_runner_container_network_mode: ""  # Deprecated alias of network
+forgejo_runner_container_enable_ipv6: ""   # true/false: IPv6 on auto-created networks
+forgejo_runner_container_privileged: ""    # true/false: privileged (required for Docker-in-Docker)
+forgejo_runner_container_options: ""    # Extra docker run options
+forgejo_runner_container_workdir_parent: ""  # Job workdir parent (empty = /workspace)
+forgejo_runner_container_valid_volumes: []   # Allowed volume globs, e.g. ['**']
+forgejo_runner_container_docker_host: ""     # Override docker host ("-" = auto, don't mount socket)
+forgejo_runner_container_force_pull: ""      # true/false: always pull images
+forgejo_runner_container_force_rebuild: ""   # true/false: always rebuild local images
+
+# host (host execution, for "<label>:host" runners)
+forgejo_runner_host_workdir_parent: ""  # Job workdir parent (empty = $HOME/.cache/act/)
+
+# Escape hatch — deep-merged on top of everything above (set any/future key here)
+forgejo_runner_extra_config: {}
+
 forgejo_runner_enable_docker: false     # Add runner user to the docker group
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -174,23 +174,76 @@ forgejo_runner_data_path: "/var/lib/forgejo-runner"  # Working directory for run
 forgejo_runner_service_enabled: true  # Enable and start runner systemd service
 forgejo_runner_service_restart_sec: "10s"  # Restart delay after failure for runner
 
-# Runner configuration settings
-forgejo_runner_log_level: "info"  # Log level: trace, debug, info, warn, error
+# Runner configuration settings (rendered into config.yml).
+# Every key the runner supports can be set below. Keys whose variable is left empty ("" / [] / {})
+# are omitted from config.yml so the runner falls back to its own built-in default. For any option
+# not modelled here (including future upstream keys), use forgejo_runner_extra_config further down.
+
+# log
+forgejo_runner_log_level: "info"  # Runner process log level: trace, debug, info, warn, error, fatal
+forgejo_runner_log_job_level: ""  # Log level for logs sent to Forgejo (defaults to log level if empty)
+
+# runner
 forgejo_runner_capacity: 1  # Number of concurrent jobs the runner can handle
-forgejo_runner_timeout: 3600  # Job timeout in seconds (1 hour default)
+forgejo_runner_timeout: 3600  # Job timeout in seconds (1 hour default; the role appends the "s" unit)
 forgejo_runner_insecure: false  # Skip TLS certificate verification (not recommended for production)
 forgejo_runner_labels: []  # Labels for the runner (e.g., ["docker:docker://node:20-bookworm"])
 forgejo_runner_runner_file: "{{ forgejo_runner_data_path }}/.runner"  # Registration state file
+forgejo_runner_envs: {}  # Extra environment variables for jobs, e.g. {KEY: value}
+forgejo_runner_env_file: ""  # Path to a file with extra job environment variables (ignored if missing)
+forgejo_runner_shutdown_timeout: ""  # Grace period for running jobs on shutdown, e.g. "3h" (0 = cancel now)
+forgejo_runner_fetch_timeout: ""  # Timeout when fetching a job from Forgejo, e.g. "5s"
+forgejo_runner_fetch_interval: ""  # Interval between job fetches, e.g. "2s"
+forgejo_runner_report_interval: ""  # Interval for reporting job status/logs, e.g. "1s"
+forgejo_runner_report_retry_max_retries: ""  # Max retries when reporting logs (int)
+forgejo_runner_report_retry_initial_delay: ""  # Initial delay between report retries, e.g. "100ms"
+forgejo_runner_report_retry_max_delay: ""  # Maximum delay between report retries, e.g. "5s"
+
+# cache (the runner's internal actions/cache server; upstream default for `enabled` is true)
+forgejo_runner_cache_enabled: ""  # true/false to enable the cache server (empty = runner default, true)
+forgejo_runner_cache_dir: ""  # Directory for cache data (empty = $HOME/.cache/actcache)
+forgejo_runner_cache_host: ""  # Host advertised to job containers (empty = auto-detect)
+forgejo_runner_cache_port: ""  # Cache server port (int; 0 = random free port)
+forgejo_runner_cache_proxy_port: ""  # Cache proxy port (int; 0 = random free port)
+forgejo_runner_cache_external_server: ""  # External cache server URL (disables the internal server)
+forgejo_runner_cache_actions_cache_url_override: ""  # Manual ACTIONS_CACHE_URL passed to containers
+forgejo_runner_cache_secret: ""  # Shared secret for cache proxy auth (store via Ansible Vault)
+forgejo_runner_cache_secret_url: ""  # File URL for the cache secret (mutually exclusive with the above)
+
+# container (Docker/Podman execution)
+forgejo_runner_container_network: ""  # Network to join: host, bridge, a custom name, or "" to auto-create
+forgejo_runner_container_network_mode: ""  # Deprecated alias of network (kept for completeness)
+forgejo_runner_container_enable_ipv6: ""  # true/false: enable IPv6 on auto-created networks
+forgejo_runner_container_privileged: ""  # true/false: privileged containers (required for Docker-in-Docker)
+forgejo_runner_container_options: ""  # Extra docker run options (e.g. "--add-host=my.forge:host-gateway")
+forgejo_runner_container_workdir_parent: ""  # Parent dir of a job's workdir (empty = /workspace)
+forgejo_runner_container_valid_volumes: []  # Allowed volume globs, e.g. ['**'] to allow any
+forgejo_runner_container_docker_host: ""  # Override docker host ("" = auto, "-" = auto + don't mount socket)
+forgejo_runner_container_force_pull: ""  # true/false: always pull images even if present
+forgejo_runner_container_force_rebuild: ""  # true/false: always rebuild local images even if cached
+
+# host (host execution, used by labels of the form "<label>:host")
+forgejo_runner_host_workdir_parent: ""  # Parent dir of a job's workdir (empty = $HOME/.cache/act/)
 
 # Runner connection / registration (Forgejo Runner v12 model)
 # The deprecated `register` command is no longer used; the connection to a Forgejo instance is
 # declared directly in config.yml under server.connections. Obtain the token (and uuid) from the
 # Forgejo UI runners page (admin: /admin/actions/runners, org/user/repo settings -> Actions ->
-# Runners). The server.connections block is only rendered when both URL and token are provided.
+# Runners). The server.connections block is rendered when the URL plus a token (or token_url) are set.
 forgejo_runner_instance_url: ""  # e.g. "https://forge.example.com/"
 forgejo_runner_registration_token: ""  # Registration token (store via Ansible Vault)
+forgejo_runner_token_url: ""  # File URL for the token, e.g. "file:$CREDENTIALS_DIRECTORY/token.txt"
 forgejo_runner_uuid: ""  # Optional runner UUID shown alongside the token in the UI
 forgejo_runner_connection_name: "forgejo"  # Key used under server.connections
+forgejo_runner_connection_labels: []  # Connection-specific runner labels (overrides runner.labels)
+forgejo_runner_connection_fetch_interval: ""  # Per-connection job fetch interval, e.g. "5s"
+
+# Escape hatch: any keys here are deep-merged on top of everything above, so you can set options
+# not modelled by the variables (including future upstream keys). Example:
+#   forgejo_runner_extra_config:
+#     container:
+#       options: "--cpus=2"
+forgejo_runner_extra_config: {}
 
 # Docker/Podman support for runner (optional)
 forgejo_runner_enable_docker: false  # Add runner user to docker group (requires Docker installed)

--- a/molecule/default/converge-runner.yml
+++ b/molecule/default/converge-runner.yml
@@ -13,6 +13,20 @@
     forgejo_runner_uuid: "00000000-0000-0000-0000-000000000000"
     forgejo_runner_labels:
       - "docker:docker://node:20-bookworm"
+    # Exercise a representative sample of the per-key variables across every config section.
+    forgejo_runner_log_job_level: "warn"
+    forgejo_runner_fetch_interval: "5s"
+    forgejo_runner_envs:
+      A_TEST_ENV: "a_test_value"
+    forgejo_runner_cache_enabled: true
+    forgejo_runner_container_privileged: true
+    forgejo_runner_container_valid_volumes:
+      - "**"
+    # extra_config is deep-merged: it adds container.options *alongside* container.privileged
+    # (set above), which proves the merge is recursive rather than a whole-section replace.
+    forgejo_runner_extra_config:
+      container:
+        options: "--cpus=2"
   tasks:
     - name: "Include sgaunet.forgejo role with runner"
       ansible.builtin.include_role:

--- a/molecule/default/verify-runner.yml
+++ b/molecule/default/verify-runner.yml
@@ -92,6 +92,32 @@
         fail_msg: "Runner config.yml is not the expected managed template"
         success_msg: "Runner config.yml is managed and declares a server connection"
 
+    - name: Parse runner configuration as YAML
+      ansible.builtin.set_fact:
+        runner_config_parsed: "{{ runner_config_content.content | b64decode | from_yaml }}"
+
+    - name: Verify runner config.yml is valid YAML and renders all sections
+      ansible.builtin.assert:
+        that:
+          # Core keys (always rendered)
+          - runner_config_parsed.log.level == "info"
+          - runner_config_parsed.runner.capacity == 1
+          # Per-key variables across the previously-unsupported sections
+          - runner_config_parsed.log.job_level == "warn"
+          - runner_config_parsed.runner.fetch_interval == "5s"
+          - runner_config_parsed.runner.envs.A_TEST_ENV == "a_test_value"
+          - runner_config_parsed.cache.enabled | bool
+          - runner_config_parsed.container.privileged | bool
+          - "'**' in runner_config_parsed.container.valid_volumes"
+          # container.options comes from forgejo_runner_extra_config and must sit *next to*
+          # container.privileged (a per-key var) — proving the deep-merge is recursive.
+          - runner_config_parsed.container.options == "--cpus=2"
+          # Connection block still renders correctly
+          - runner_config_parsed.server.connections.forgejo.url == "http://localhost:3000/"
+          - runner_config_parsed.server.connections.forgejo.token is defined
+        fail_msg: "Runner config.yml is missing expected keys (per-key vars or extra_config deep-merge)"
+        success_msg: "Runner config.yml renders all sections, including the extra_config deep-merge"
+
     - name: Check forgejo-runner service file exists
       ansible.builtin.stat:
         path: /etc/systemd/system/forgejo-runner.service

--- a/templates/config.yml.j2
+++ b/templates/config.yml.j2
@@ -1,27 +1,66 @@
 # {{ ansible_managed }}
 # Forgejo Runner configuration managed by the sgaunet.forgejo Ansible role.
-# Only the keys managed by the role are listed here; any option left out falls back to the
-# runner's built-in default. See the upstream config.example.yaml for the full reference:
+# Every key exposed by the runner can be set through a `forgejo_runner_*` variable (see
+# defaults/main.yml) or via the free-form `forgejo_runner_extra_config` dict, which is
+# deep-merged last. Keys whose variable is left empty are omitted here, so the runner falls
+# back to its own built-in default. Upstream reference:
 # https://code.forgejo.org/forgejo/runner/src/branch/main/internal/pkg/config/config.example.yaml
 ---
-log:
-  level: {{ forgejo_runner_log_level }}
-
-runner:
-  file: {{ forgejo_runner_runner_file }}
-  capacity: {{ forgejo_runner_capacity }}
-  timeout: {{ forgejo_runner_timeout }}s
-  insecure: {{ forgejo_runner_insecure | lower }}
-  labels: {{ forgejo_runner_labels | to_json }}
-{% if forgejo_runner_instance_url and forgejo_runner_registration_token %}
-
-# Connection to the Forgejo instance (v12 replaces the deprecated `register` command).
-server:
-  connections:
-    {{ forgejo_runner_connection_name }}:
-      url: {{ forgejo_runner_instance_url }}
-{% if forgejo_runner_uuid %}
-      uuid: {{ forgejo_runner_uuid }}
+{# ----- log ----------------------------------------------------------------- #}
+{% set _log = {'level': forgejo_runner_log_level} %}
+{% if forgejo_runner_log_job_level %}{% set _log = _log | combine({'job_level': forgejo_runner_log_job_level}) %}{% endif %}
+{# ----- runner -------------------------------------------------------------- #}
+{% set _runner = {'file': forgejo_runner_runner_file, 'capacity': forgejo_runner_capacity | int, 'timeout': (forgejo_runner_timeout | string) ~ 's', 'insecure': forgejo_runner_insecure | bool, 'labels': forgejo_runner_labels} %}
+{% if forgejo_runner_envs | length > 0 %}{% set _runner = _runner | combine({'envs': forgejo_runner_envs}) %}{% endif %}
+{% if forgejo_runner_env_file %}{% set _runner = _runner | combine({'env_file': forgejo_runner_env_file}) %}{% endif %}
+{% if forgejo_runner_shutdown_timeout %}{% set _runner = _runner | combine({'shutdown_timeout': forgejo_runner_shutdown_timeout}) %}{% endif %}
+{% if forgejo_runner_fetch_timeout %}{% set _runner = _runner | combine({'fetch_timeout': forgejo_runner_fetch_timeout}) %}{% endif %}
+{% if forgejo_runner_fetch_interval %}{% set _runner = _runner | combine({'fetch_interval': forgejo_runner_fetch_interval}) %}{% endif %}
+{% if forgejo_runner_report_interval %}{% set _runner = _runner | combine({'report_interval': forgejo_runner_report_interval}) %}{% endif %}
+{% set _report_retry = {} %}
+{% if forgejo_runner_report_retry_max_retries != '' %}{% set _report_retry = _report_retry | combine({'max_retries': forgejo_runner_report_retry_max_retries | int}) %}{% endif %}
+{% if forgejo_runner_report_retry_initial_delay %}{% set _report_retry = _report_retry | combine({'initial_delay': forgejo_runner_report_retry_initial_delay}) %}{% endif %}
+{% if forgejo_runner_report_retry_max_delay %}{% set _report_retry = _report_retry | combine({'max_delay': forgejo_runner_report_retry_max_delay}) %}{% endif %}
+{% if _report_retry %}{% set _runner = _runner | combine({'report_retry': _report_retry}) %}{% endif %}
+{# ----- cache --------------------------------------------------------------- #}
+{% set _cache = {} %}
+{% if forgejo_runner_cache_enabled != '' %}{% set _cache = _cache | combine({'enabled': forgejo_runner_cache_enabled | bool}) %}{% endif %}
+{% if forgejo_runner_cache_dir %}{% set _cache = _cache | combine({'dir': forgejo_runner_cache_dir}) %}{% endif %}
+{% if forgejo_runner_cache_host %}{% set _cache = _cache | combine({'host': forgejo_runner_cache_host}) %}{% endif %}
+{% if forgejo_runner_cache_port != '' %}{% set _cache = _cache | combine({'port': forgejo_runner_cache_port | int}) %}{% endif %}
+{% if forgejo_runner_cache_proxy_port != '' %}{% set _cache = _cache | combine({'proxy_port': forgejo_runner_cache_proxy_port | int}) %}{% endif %}
+{% if forgejo_runner_cache_external_server %}{% set _cache = _cache | combine({'external_server': forgejo_runner_cache_external_server}) %}{% endif %}
+{% if forgejo_runner_cache_actions_cache_url_override %}{% set _cache = _cache | combine({'actions_cache_url_override': forgejo_runner_cache_actions_cache_url_override}) %}{% endif %}
+{% if forgejo_runner_cache_secret %}{% set _cache = _cache | combine({'secret': forgejo_runner_cache_secret}) %}{% endif %}
+{% if forgejo_runner_cache_secret_url %}{% set _cache = _cache | combine({'secret_url': forgejo_runner_cache_secret_url}) %}{% endif %}
+{# ----- container ----------------------------------------------------------- #}
+{% set _container = {} %}
+{% if forgejo_runner_container_network %}{% set _container = _container | combine({'network': forgejo_runner_container_network}) %}{% endif %}
+{% if forgejo_runner_container_network_mode %}{% set _container = _container | combine({'network_mode': forgejo_runner_container_network_mode}) %}{% endif %}
+{% if forgejo_runner_container_enable_ipv6 != '' %}{% set _container = _container | combine({'enable_ipv6': forgejo_runner_container_enable_ipv6 | bool}) %}{% endif %}
+{% if forgejo_runner_container_privileged != '' %}{% set _container = _container | combine({'privileged': forgejo_runner_container_privileged | bool}) %}{% endif %}
+{% if forgejo_runner_container_options %}{% set _container = _container | combine({'options': forgejo_runner_container_options}) %}{% endif %}
+{% if forgejo_runner_container_workdir_parent %}{% set _container = _container | combine({'workdir_parent': forgejo_runner_container_workdir_parent}) %}{% endif %}
+{% if forgejo_runner_container_valid_volumes | length > 0 %}{% set _container = _container | combine({'valid_volumes': forgejo_runner_container_valid_volumes}) %}{% endif %}
+{% if forgejo_runner_container_docker_host %}{% set _container = _container | combine({'docker_host': forgejo_runner_container_docker_host}) %}{% endif %}
+{% if forgejo_runner_container_force_pull != '' %}{% set _container = _container | combine({'force_pull': forgejo_runner_container_force_pull | bool}) %}{% endif %}
+{% if forgejo_runner_container_force_rebuild != '' %}{% set _container = _container | combine({'force_rebuild': forgejo_runner_container_force_rebuild | bool}) %}{% endif %}
+{# ----- host ---------------------------------------------------------------- #}
+{% set _host = {} %}
+{% if forgejo_runner_host_workdir_parent %}{% set _host = _host | combine({'workdir_parent': forgejo_runner_host_workdir_parent}) %}{% endif %}
+{# ----- assemble top-level config ------------------------------------------- #}
+{% set _config = {'log': _log, 'runner': _runner} %}
+{% if _cache %}{% set _config = _config | combine({'cache': _cache}) %}{% endif %}
+{% if _container %}{% set _config = _config | combine({'container': _container}) %}{% endif %}
+{% if _host %}{% set _config = _config | combine({'host': _host}) %}{% endif %}
+{# ----- server.connections (v12 replaces the deprecated `register` command) -- #}
+{% if forgejo_runner_instance_url and (forgejo_runner_registration_token or forgejo_runner_token_url) %}
+{% set _conn = {'url': forgejo_runner_instance_url} %}
+{% if forgejo_runner_uuid %}{% set _conn = _conn | combine({'uuid': forgejo_runner_uuid}) %}{% endif %}
+{% if forgejo_runner_registration_token %}{% set _conn = _conn | combine({'token': forgejo_runner_registration_token}) %}{% endif %}
+{% if forgejo_runner_token_url %}{% set _conn = _conn | combine({'token_url': forgejo_runner_token_url}) %}{% endif %}
+{% if forgejo_runner_connection_labels | length > 0 %}{% set _conn = _conn | combine({'labels': forgejo_runner_connection_labels}) %}{% endif %}
+{% if forgejo_runner_connection_fetch_interval %}{% set _conn = _conn | combine({'fetch_interval': forgejo_runner_connection_fetch_interval}) %}{% endif %}
+{% set _config = _config | combine({'server': {'connections': {forgejo_runner_connection_name: _conn}}}) %}
 {% endif %}
-      token: {{ forgejo_runner_registration_token }}
-{% endif %}
+{{ _config | combine(forgejo_runner_extra_config, recursive=True) | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
- Add per-key forgejo_runner_* vars for log/runner/cache/container/host/
  server (33 new) plus a deep-merged forgejo_runner_extra_config escape hatch
- Render config.yml from a dict via to_nice_yaml; omit unset keys so the
  runner keeps its own defaults (deterministic, idempotent)
- Document all new variables in README.md; update CLAUDE.md
- Extend runner molecule scenario to assert the new sections and the
  extra_config deep-merge

Closes #24